### PR TITLE
fix 'undefined reference to symbol floor@@GLIBC' when linking tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCES)
 add_executable(evfibers_test ${TEST_SOURCES})
-target_link_libraries(evfibers_test ev evfibers check)
+target_link_libraries(evfibers_test ev evfibers check m rt)
 enable_testing()
 add_test(evfibers_test ${CMAKE_CURRENT_BINARY_DIR}/evfibers_test)
 add_custom_target(test COMMAND ${CMAKE_CTEST_COMMAND}


### PR DESCRIPTION
Add missing libraries to build evfibers_test on newer Linux'es
