### PR TITLE
generate and install a pkg-config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,18 @@ endif(WANT_EIO AND THREADS_FOUND AND LIBEIO_FOUND)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/evfibers/config.h.in"
 	"${CMAKE_CURRENT_BINARY_DIR}/include/evfibers/config.h")
 
+# provide pkg-config file
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libevfibers.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libevfibers.pc @ONLY
+)
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/libevfibers.pc
+  DESTINATION
+    "lib/pkgconfig"
+)
+
 subdirs(test)
 
 if(NOT EVFIBERS_EMBED)

--- a/libevfibers.pc.in
+++ b/libevfibers.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}/bin
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libevfibers
+Description: Small C fiber library that uses libev based event loop and libcoro based coroutine context switching
+Version: @VERSION_STRING@
+URL: https://github.com/Lupus/libevfibers
+Requires:
+Libs: -L${libdir} -levfibers
+Libs.private: -lev @CMAKE_THREAD_LIBS_INIT@
+Cflags: -I${includedir} 


### PR DESCRIPTION
Addresses issue #11 .  The net result is that make install will create a PREFIX/lib/pkgconfig/libevfibers.pc file.  This will allow the pkg-config utility (popular in some autotools projects) to query the libs and cflags that dependent projects should use for libevfibers.