### PR TITLE
add fbr_async_wait() call and test program

### DIFF
--- a/include/evfibers/fiber.h
+++ b/include/evfibers/fiber.h
@@ -1408,6 +1408,15 @@ int fbr_accept(FBR_P_ int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 ev_tstamp fbr_sleep(FBR_P_ ev_tstamp seconds);
 
 /**
+ * Waits for an async libev event.
+ * @param [in] w ev_async watcher (initialized by caller)
+ *
+ * This function will cause the calling fiber to wait until an
+ * ev_async_send() has been triggered on the specified ev_async watcher.
+ */
+void fbr_async_wait(FBR_P_ ev_async *w);
+
+/**
  * Prints fiber call stack to stderr.
  *
  * useful while debugging obscure fiber call problems.

--- a/src/fiber.c
+++ b/src/fiber.c
@@ -1430,6 +1430,30 @@ ev_tstamp fbr_sleep(FBR_P_ ev_tstamp seconds)
 	return max(0., expected - ev_now(fctx->__p->loop));
 }
 
+static void watcher_async_dtor(FBR_P_ void *_arg)
+{
+	struct ev_async *w = _arg;
+	ev_async_stop(fctx->__p->loop, w);
+}
+
+void fbr_async_wait(FBR_P_ ev_async *w)
+{
+	struct fbr_ev_watcher watcher;
+	struct fbr_destructor dtor = FBR_DESTRUCTOR_INITIALIZER;
+
+	dtor.func = watcher_async_dtor;
+	dtor.arg = w;
+	fbr_destructor_add(FBR_A_ &dtor);
+
+	fbr_ev_watcher_init(FBR_A_ &watcher, (ev_watcher *)w);
+	fbr_ev_wait_one(FBR_A_ &watcher.ev_base);
+
+	fbr_destructor_remove(FBR_A_ &dtor, 0 /* Call it? */);
+	ev_async_stop(fctx->__p->loop, w);
+
+	return;
+}
+
 static long get_page_size()
 {
 	static long sz;

--- a/test/async-wait.c
+++ b/test/async-wait.c
@@ -1,0 +1,121 @@
+/********************************************************************
+
+   Copyright 2013 Konstantin Olkhovskiy <lupus@oxnull.net>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ ********************************************************************/
+
+#include <ev.h>
+#include <check.h>
+#include <evfibers_private/fiber.h>
+
+#include "async-wait.h"
+
+struct fiber_arg {
+	ev_async *async;
+	fbr_id_t *fibers;
+};
+
+static int async_recvd = 0;
+
+static void async_sender(FBR_P_ void *_arg)
+{
+	struct fiber_arg *arg = _arg;
+	ev_async *async = arg->async;
+
+	/* wait briefly to make sure other fiber blocks */
+	fbr_sleep(FBR_A_ 1);
+
+	/* send async event in libev to wake up other fiber */
+	ev_async_send(fctx->__p->loop, async);
+	return;
+}
+
+static void async_waiter(FBR_P_ void *_arg)
+{
+	struct fiber_arg *arg = _arg;
+	ev_async *async = arg->async;
+
+	fbr_async_wait(FBR_A_ async);
+
+	async_recvd = 1;
+
+	return;
+}
+
+static void async_handler_cb(EV_P_ ev_async *w, int revents)
+{
+	/* hush warnings */
+	(void)w;
+	(void)revents;
+
+	async_recvd = 1;
+	/* This is kind of a hack for testing purposes; make sure we break out of
+	 * the underlying event loop
+	 */
+	ev_break(EV_A_ EVBREAK_ONE);
+
+	return;
+}
+
+START_TEST(test_async_wait)
+{
+	struct fbr_context context;
+	fbr_id_t fibers[2] = {
+		FBR_ID_NULL,
+		FBR_ID_NULL,
+	};
+	ev_async async;
+	int retval;
+	struct fiber_arg arg;
+
+	fbr_init(&context, EV_DEFAULT);
+
+	ev_async_init(&async, async_handler_cb);
+	ev_async_start(EV_DEFAULT, &async);
+	
+	arg.fibers = fibers;
+	arg.async = &async;
+
+	fibers[0] = fbr_create(&context, "async_sender", async_sender, &arg, 0);
+	fail_if(fbr_id_isnull(fibers[0]), NULL);
+	fibers[1] = fbr_create(&context, "async_waiter", async_waiter, &arg, 0);
+	fail_if(fbr_id_isnull(fibers[1]), NULL);
+
+	retval = fbr_transfer(&context, fibers[1]);
+	fail_unless(0 == retval, NULL);
+	/* it should not have recieved async event yet; the next fiber will
+	 * do that
+	 */
+	fail_unless(0 == async_recvd);
+
+	retval = fbr_transfer(&context, fibers[0]);
+	fail_unless(0 == retval, NULL);
+
+	/* Run the event loop */
+	ev_run(EV_DEFAULT, 0);
+
+	fail_unless(1 == async_recvd);
+
+	fbr_destroy(&context);
+}
+END_TEST
+
+TCase * async_wait_tcase(void)
+{
+	TCase *tc_async_wait = tcase_create ("Async_wait");
+	tcase_add_test(tc_async_wait, test_async_wait);
+	return tc_async_wait;
+}
+

--- a/test/async-wait.h
+++ b/test/async-wait.h
@@ -1,0 +1,24 @@
+/********************************************************************
+
+   Copyright 2013 Konstantin Olkhovskiy <lupus@oxnull.net>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+ ********************************************************************/
+
+#ifndef _ASYNC_WAIT_H_
+#define _ASYNC_WAIT_H_
+
+TCase * async_wait_tcase(void);
+
+#endif

--- a/test/main.c
+++ b/test/main.c
@@ -30,12 +30,13 @@
 #include "buffer.h"
 #include "key.h"
 #include "eio.h"
+#include "async-wait.h"
 
 Suite *evfibers_suite(void)
 {
 	Suite *s;
 	TCase *tc_init, *tc_mutex, *tc_cond, *tc_reclaim, *tc_io, *tc_logger,
-	      *tc_buffer, *tc_key, *tc_eio;
+	      *tc_buffer, *tc_key, *tc_eio, *tc_async_wait;
 
 	s = suite_create ("evfibers");
 	tc_init = init_tcase();
@@ -47,6 +48,7 @@ Suite *evfibers_suite(void)
 	tc_buffer = buffer_tcase();
 	tc_key = key_tcase();
 	tc_eio = eio_tcase();
+	tc_async_wait = async_wait_tcase();
 	suite_add_tcase(s, tc_init);
 	suite_add_tcase(s, tc_mutex);
 	suite_add_tcase(s, tc_cond);
@@ -56,6 +58,7 @@ Suite *evfibers_suite(void)
 	suite_add_tcase(s, tc_buffer);
 	suite_add_tcase(s, tc_key);
 	suite_add_tcase(s, tc_eio);
+	suite_add_tcase(s, tc_async_wait);
 
 	return s;
 }


### PR DESCRIPTION
This adds the ability for a fiber to wait for a libev async event to arrive.  This helpful if you have to integrate with an external API that uses a thread for progress because it provides a thread-safe mechanism to alert fibers about activity that needs attention.