### PR TITLE
initial OSX support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
-install: sudo apt-get install cmake libev-dev check cvs libtool autoconf
+install: "./ci/install_deps.sh"
 language: c
 script: "./ci/run_tests.sh"
+os:
+        - linux
+        - osx
 compiler:
         - clang
         - gcc
 env:
         - BUILD_TYPE=RelWithDebInfo EIO="-DWANT_EIO=TRUE -DWANT_EMBEDDED_EIO=TRUE"
         - BUILD_TYPE=RelWithDebInfo EIO="-DWANT_EIO=FALSE"
+# gcc is symlinked to clang on OSX - could install with homebrew and fiddle
+# with paths to make sure the one we want is being used, but save that for
+# another day if interest arises
+matrix:
+    exclude:
+        - os: osx
+          compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(VERSION_PATCH 1)
 set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
 include(CheckIncludeFiles)
+include(CheckCCompilerFlag)
 
 if(NOT DEFINED WANT_EIO)
 	message(STATUS "WANT_EIO flag not specified, defaulting to TRUE")
@@ -30,9 +31,46 @@ endif(NOT DEFINED WANT_EIO)
 aux_source_directory("${CMAKE_CURRENT_SOURCE_DIR}/src" EVFIBERS_SOURCES)
 aux_source_directory("${CMAKE_CURRENT_SOURCE_DIR}/coro" CORO_SOURCES)
 
+# OSX-related checks - linking, using ucontext, etc. is slightly different than
+# on linux
+if(APPLE)
+	# def needed to get ucontext support
+	set(CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} -D_XOPEN_SOURCE")
+	add_definitions(-D_XOPEN_SOURCE)
+	# ucontext is labeled deprecated, so make sure -Werror doesn't kill the
+	# compile
+	set(CMAKE_C_FLAGS "-Wno-error=deprecated-declarations ${CMAKE_C_FLAGS}")
+	# OSX uses MAP_ANON for mmap while linux uses MAP_ANONYMOUS
+	set(FBR_MAP_ANON_FLAG MAP_ANON)
+	set(EIO_LD_WHOLE_ARCHIVE -Wl,-all_load)
+	set(EIO_LD_NOWHOLE_ARCHIVE )
+	# use of swapcontext hits false positives on OSX when using either
+	# address-sanitizer or stack protector (stack protector is on by default in
+	# clang). Disable them.
+	if(WANT_ASAN)
+		message(WARNING "Address sanitizer causes false positive errors for makecontext/swapcontext on OSX, disabling...")
+		set(WANT_ASAN FALSE)
+	endif(WANT_ASAN)
+	CHECK_C_COMPILER_FLAG("-fno-stack-protector" FBR_HAS_NO_STACK_PROTECT)
+	if(FBR_HAS_NO_STACK_PROTECT)
+		set(CMAKE_C_FLAGS "-fno-stack-protector ${CMAKE_C_FLAGS}")
+	endif(FBR_HAS_NO_STACK_PROTECT)
+else(APPLE)
+	set(FBR_MAP_ANON_FLAG MAP_ANONYMOUS)
+	set(EIO_LD_WHOLE_ARCHIVE -Wl,-whole-archive)
+	set(EIO_LD_NOWHOLE_ARCHIVE -Wl,-no-whole-archive)
+endif(APPLE)
+
+# need to provide this define on the command line instead of config.h so
+# we don't have to modify the embedded libcoro.
+check_include_files(ucontext.h HAVE_UCONTEXT_H)
+if(HAVE_UCONTEXT_H)
+	add_definitions(-DHAVE_UCONTEXT_H)
+endif(HAVE_UCONTEXT_H)
+
 find_package(LibEv REQUIRED)
 if(WANT_EIO)
-	find_package(Threads)
+	find_package(Threads REQUIRED)
 	if(WANT_EMBEDDED_EIO)
 		include(ExternalProject)
 		ExternalProject_Add(
@@ -62,7 +100,10 @@ if(WANT_EIO)
 			DEPENDEES install
 		)
 		set(LIBEIO_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/eio/include")
-		set(LIBEIO_LIBRARY "-L${CMAKE_CURRENT_BINARY_DIR}/eio/lib -Wl,-whole-archive -leio -Wl,-no-whole-archive ${CMAKE_THREAD_LIBS_INIT}")
+		set(LIBEIO_LIBRARY
+			"-L${CMAKE_CURRENT_BINARY_DIR}/eio/lib"
+			"${EIO_LD_WHOLE_ARCHIVE}" "-leio" "${EIO_LD_NOWHOLE_ARCHIVE}"
+			"${CMAKE_THREAD_LIBS_INIT}")
 		set(LIBEIO_FOUND TRUE)
                 set(FBR_USE_EMBEDDED_EIO TRUE)
 	else(WANT_EMBEDDED_EIO)
@@ -73,6 +114,7 @@ endif(WANT_EIO)
 if(WANT_ASAN)
 	# Force ucontext.h as libcoro backend so as to better interact with ASan
 	add_definitions(-DCORO_UCONTEXT)
+	set(ASAN_FLAGS "-fsanitize=address")
 endif(WANT_ASAN)
 
 if(WANT_VALGRIND)
@@ -93,9 +135,6 @@ include_directories(
 if(WANT_LTO)
 	set(LTO_FLAGS "-flto")
 endif(WANT_LTO)
-if(WANT_ASAN)
-	set(ASAN_FLAGS "-fsanitize=address")
-endif(WANT_ASAN)
 set(CMAKE_C_FLAGS "-W -Wall -Werror -fno-strict-aliasing ${LTO_FLAGS} ${ASAN_FLAGS} ${CMAKE_C_FLAGS}")
 set(SOURCES ${EVFIBERS_SOURCES} ${CORO_SOURCES})
 

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+os=$(uname -s)
+err=
+if [[ "$os" == "Linux" ]] ; then
+    sudo apt-get install cmake libev-dev check cvs libtool autoconf
+    err=$?
+elif [[ "$os" == "Darwin" ]] ; then
+    brew install cmake libev check cvs libtool autoconf
+    err=$?
+else
+    echo "Unrecognized OS: $os" >&2
+    err=1
+fi
+
+exit $err

--- a/include/evfibers/config.h.in
+++ b/include/evfibers/config.h.in
@@ -22,5 +22,6 @@
 #cmakedefine HAVE_VALGRIND_H
 #cmakedefine FBR_EIO_ENABLED
 #cmakedefine FBR_USE_EMBEDDED_EIO
+#cmakedefine FBR_MAP_ANON_FLAG @FBR_MAP_ANON_FLAG@
 
 #endif

--- a/src/fiber.c
+++ b/src/fiber.c
@@ -20,7 +20,6 @@
 
 #include <sys/mman.h>
 #include <fcntl.h>
-#include <linux/limits.h>
 #include <libgen.h>
 #include <assert.h>
 #include <errno.h>
@@ -1763,7 +1762,7 @@ int fbr_vrb_init(struct fbr_vrb *vrb, size_t size, const char *file_pattern)
 	//fctx->__p->vrb_file_pattern);
 	vrb->mem_ptr_size = size * 2 + sz * 2;
 	vrb->mem_ptr = mmap(NULL, vrb->mem_ptr_size, PROT_NONE,
-			MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+			FBR_MAP_ANON_FLAG | MAP_PRIVATE, -1, 0);
 	if (MAP_FAILED == vrb->mem_ptr)
 		goto error;
 	vrb->lower_ptr = vrb->mem_ptr + sz;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,15 @@
 aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} TEST_SOURCES)
+if (APPLE)
+	# don't want to test mknod - requires super-user privileges
+	add_definitions(-DFBR_TEST_NO_MKNOD)
+else(APPLE)
+	# OSX doesn't use librt, while linux boxes do
+	set(FBR_TEST_RTLIB rt)
+endif(APPLE)
+
 add_executable(evfibers_test ${TEST_SOURCES})
-target_link_libraries(evfibers_test ev evfibers check m rt)
+target_link_libraries(evfibers_test evfibers check m ${FBR_TEST_RTLIB})
 enable_testing()
 add_test(evfibers_test ${CMAKE_CURRENT_BINARY_DIR}/evfibers_test)
-add_custom_target(test COMMAND ${CMAKE_CTEST_COMMAND}
+add_custom_target(tests COMMAND ${CMAKE_CTEST_COMMAND}
 	DEPENDS evfibers_test)

--- a/test/eio.c
+++ b/test/eio.c
@@ -232,8 +232,16 @@ static void io_fiber(FBR_P_ _unused_ void *_arg)
 	retval = fbr_eio_rmdir(FBR_A_ "./async.test.dir", 0);
 	assert(0 == retval);
 
+#ifdef FBR_TEST_NO_MKNOD
+	fd = fbr_eio_open(FBR_A_ "./async.node", O_RDWR | O_CREAT | O_TRUNC,
+			0644, 0);
+	fail_unless(0 <= fd);
+	retval = fbr_eio_close(FBR_A_ fd, 0);
+	fail_unless(0 == retval);
+#else
 	retval = fbr_eio_mknod(FBR_A_ "./async.node", 0644, S_IFREG, 0);
 	assert(0 == retval);
+#endif
 
 	retval = fbr_eio_link(FBR_A_ "./async.node",
 			"./async.node.link", 0);


### PR DESCRIPTION
Nothing too significant done to the codebase itself, more about getting the
right build flags for the right platform and dealing with a few random issues
here and there (mknod on OSX requires superuser privileges, which broke some
tests). However, the test suite is not yet green - the "test_premature_cond"
test is failing (at test/cond.c:246).

Before I dig deeper into the cause, I thought I'd get some initial feedback on the build sys changes. I'm new to both cmake and OSX, so there's likely a better way to accomplish this :).